### PR TITLE
Add pagination and fix N+1 query issue for People index

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "jbuilder"
 gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 gem 'slim-rails'
 gem "jsbundling-rails"
+gem "kaminari"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,18 @@ GEM
       activesupport (>= 5.0.0)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     logger (1.6.1)
     loofah (2.23.1)
       crass (~> 1.0.2)
@@ -290,6 +302,7 @@ DEPENDENCIES
   faker
   jbuilder
   jsbundling-rails
+  kaminari
   pry-rails
   puma (~> 5.0)
   rails (~> 7.0.1)

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -1,7 +1,7 @@
 class PeopleController < ApplicationController
 
   def index
-    @people = Person.all
+    @people = Person.includes(:company)
   end
 
   def new

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -1,7 +1,7 @@
 class PeopleController < ApplicationController
 
   def index
-    @people = Person.includes(:company)
+    @people = Person.includes(:company).page(params[:page])
   end
 
   def new

--- a/app/views/kaminari/_first_page.html.slim
+++ b/app/views/kaminari/_first_page.html.slim
@@ -1,0 +1,2 @@
+li.page-item
+  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link'

--- a/app/views/kaminari/_gap.html.slim
+++ b/app/views/kaminari/_gap.html.slim
@@ -1,0 +1,2 @@
+li.page-item.disabled
+  = link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link'

--- a/app/views/kaminari/_last_page.html.slim
+++ b/app/views/kaminari/_last_page.html.slim
@@ -1,0 +1,2 @@
+li.page-item
+  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link'

--- a/app/views/kaminari/_next_page.html.slim
+++ b/app/views/kaminari/_next_page.html.slim
@@ -1,0 +1,2 @@
+li.page-item
+  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link'

--- a/app/views/kaminari/_page.html.slim
+++ b/app/views/kaminari/_page.html.slim
@@ -1,0 +1,6 @@
+- if page.current?
+  li.page-item.active
+    = content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link'
+- else
+  li.page-item
+    = link_to page, url, remote: remote, rel: page.rel, class: 'page-link'

--- a/app/views/kaminari/_paginator.html.slim
+++ b/app/views/kaminari/_paginator.html.slim
@@ -1,0 +1,12 @@
+= paginator.render do
+  nav
+    ul.pagination
+      == first_page_tag unless current_page.first?
+      == prev_page_tag unless current_page.first?
+      - each_page do |page|
+        - if page.left_outer? || page.right_outer? || page.inside_window?
+          == page_tag page
+        - elsif !page.was_truncated?
+          == gap_tag
+      == next_page_tag unless current_page.last?
+      == last_page_tag unless current_page.last?

--- a/app/views/kaminari/_prev_page.html.slim
+++ b/app/views/kaminari/_prev_page.html.slim
@@ -1,0 +1,2 @@
+li.page-item
+  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link'

--- a/app/views/people/index.html.slim
+++ b/app/views/people/index.html.slim
@@ -12,10 +12,9 @@ table.table
     - @people.each do |person|
       tr
         th[scope="row"]= person&.id
-        td= person.try(:name)
-        td= person.try(:phone)
-        td= person.try(:email)
-        td= person.try(:company).try(:name)
+        td= person&.name
+        td= person&.phone_number
+        td= person&.email
+        td= person&.company&.name
 
-
-
+= paginate @people

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,3 @@
+Kaminari.configure do |config|
+  config.default_per_page = 10
+end


### PR DESCRIPTION
Introduced pagination using Kaminari for the People index (10 entries per page) and fixed an N+1 query issue by eager loading Companies with People for better performance.

## Screenshot:
<img width="1338" alt="Screenshot 2025-01-21 at 12 11 27 AM" src="https://github.com/user-attachments/assets/85387f30-49df-4d46-9b94-fd16015fffcc" />
